### PR TITLE
Module source imports

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="./spec.js"></script>
 <pre class="metadata">
-title: Module Instance Imports
+title: Static Module Instance & Module Source
 stage: 0
 contributors: Luca Casonato
 </pre>


### PR DESCRIPTION
This extends the proposal to also define `ModuleSource` for ECMAScript modules.

In the process I added two new constraints and one feature:

1. Module instance is no longer structured cloneable, to avoid defining instance identity between contexts, instead it can only be used to create top-level workers via `new Worker(instance)`, but not via transfer.
2. Module source **is** structured cloneable, supporting transfer but not worker initialization.

As a new feature, to make module source usable without having virtualization primitives yet, we extend module source to also support import via `import(moduleSource)` where that just means importing the instance of the module source in the current context.

Instead of defining what it means for an instance graph to be transferred, we thus only define what it means for a source to be transferred, and then define the concept of the "canonical loader registry instance" for every source in every context. It's a little bit of a round about way of defining something like instance identity across contexts, but I think it gets us out of a lot of the stick problems by firstly reducing instance identity to the static cases, and then secondly just to singular sources without pretending we are sharing linking information. Instead we allow the initial `new Worker(instance)` to create a new worker that from the start shares its linkage with the main thread. In this way we separate worker resolution context from module resolution context while having a consistent definition of global registry identity. It's a mouthful, but perhaps its close to the right kind of tradeoffs.