### PR TITLE
Clarify worker problem statement, rename to 'Source Text Phase Imports'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Source Text Phase Imports
+# ECMAScript Module Phase Imports
 
 ## Status
 
@@ -67,7 +67,7 @@ By defining a new phase for ECMAScript module records, it is possible to
 import a handle to a module statically, and pass this handle to the worker:
 
 ```js
-import somephase myModule from "./my-module.js";
+import instanceOrSource myModule from "./my-module.js";
 
 // `{ type: 'module' }` can be inferred since myModule is a module object
 const worker = new Worker(myModule);
@@ -91,7 +91,7 @@ Since phases also support a dynamic import form, we would also get the dynamic
 variant:
 
 ```js
-const workerModule = await import.somephase('./worker.js');
+const workerModule = await import.instanceOrSource('./worker.js');
 new Worker(workerModule);
 ```
 
@@ -105,21 +105,22 @@ These phases form the basis of a number of new proposals for modules including
 module declarations, module expressions, deferred module imports, virtualization
 through loaders and new worker semantics.
 
-In order to develop these new proposals in a way that aligns with phased
-imports,Currently this phase is not yet specified for ECMAScript modules
-themselves, as we do not have a definition of this object yet for JavaScript.
+Currently these phases are not yet specified for ECMAScript modules themselves,
+, as we do not have a specifications of any of these objects yet for JavaScript.
 
-One of the driving specification constraints for these objects is also how they
-behave when transferred between agents and workers, which we would argue forms
-a critical design space for these features, which is why this proposal is seen
-as the most suitable "next step" in the larger layering efforts.
+One of the driving specification constraints for these objects is how they
+behave for workers and other agents, which we would argue forms a critical
+design constraint for these features. This is why this proposal's problem
+statement is seen as the most suitable "next step" in the larger module harmony
+layering efforts, with the phase object or objects specified here to support the
+layering of future proposals.
 
 ## Design Questions
 
 ### Module Instance v Module Source
 
-There is an outstanding design question as to whether this phase should be an
-instance or source phase for the module.
+There is the outstanding design question as to whether this phase should be the
+instance phase or the source phase for the module.
 
 The instance phase represents an entire graph of modules, while the source phase
 represents just a specific module source without its linking being defined.
@@ -127,10 +128,10 @@ represents just a specific module source without its linking being defined.
 The benefit of the instance phase being that because it represents the graph, it
 might be more amenable to preloading.
 
-Work to determine which phase to specify is ongoing within this proposal's
-current stage. It may yet specify one or the other, or it may even specify
-_both_ a source and an instance to allow handling some of the deeper tradeoffs
-and layering questions.
+As part of the design progression process, it will be determined that this
+proposal will end up specifying one or the other, or possibly both a source and
+an instance phase for the chosen solution to the use case and layering
+requirements.
 
 ### Transferability
 

--- a/README.md
+++ b/README.md
@@ -6,58 +6,32 @@ Champion(s): Luca Casonato, Guy Bedford
 
 Stage: 0
 
-## Background
-
-With the recently introduced [source phase]() imports, it is now possible to
-define import phases that exist prior to the full link and execution of the
-module graph.
-
-These phases form the basis of a number of new proposals for modules including
-module declarations, module expressions, deferred module imports, virtualization
-through loaders and new worker semantics.
-
-Currently this phase is not yet specified for ECMAScript modules themselves,
-as we do not have a definition of this object yet for JavaScript.
-
-One of the driving specification constraints for these objects is also how they
-behave when transferred between agents and workers, which we would argue forms
-a critical design space for these features.
-
 ## Problem Statement
 
-This proposal seeks to solve the "static worker" module problem for JavaScript,
-through defining a suitable source phase import for SourceTextModule.
+This proposal seeks to solve the _static worker_ module analysis problem for
+JavaScript, through defining a suitable phase import for SourceTextModule.
 
-### The Worker Static Module Analysis Problem
+## Motivation
 
-`new Worker()` is a case where the relation between two modules suffers from a
-number of analysis issues:
+Improving runtime and tooling support for workers will enable faster JavaScript
+applications.
 
-1. It always takes an arbitrary expression to locate the worker URL, like
-   dynamic `import()` does. We thus never have fully static worker includes like
-   we do for normal ESM imports and workers therefore always fall under some
-   kind of advanced expression analysis / partial evaluation case in tooling.
+The `new Worker()` constructor pattern that is currently relied on for these
+workflows suffers from a number of analysis issues:
+
+1. It always takes an arbitrary expression to locate the worker URL. The worker
+   is not just a _static import_, like normal ESM imports.
 2. The string passed to `new Worker(url)` doesn't support module resolution
-   rules - relative URLs are not resolved module-relative but baseURL-relative,
-   which will be different at runtime versus build / analysis time. For this
-   reason it is often impossible to locate workers without an out-of-band
-   baseURL-based rooting configuration for the analysis system and for the
-   runtime system. The best pattern here is to first resolve URLs using
-   `import.meta.resolve()` or `import.meta.url`, but there are many different
-   patterns here and no single standard approache employed by developers.
-3. `Worker` is a global variable, unlike dynamic `import()`, so that we can't
-   even rely on that binding as a reliable sink for worker URL invocation
-   expression analysis.
+   rules. Because relative URLs are resolved baseURL-relative, users usually
+   need to rely on a resolution function first, such as an out-of-band
+   configuration or expressions involving `import.meta.resolve()` or
+   `import.meta.url`. There are many different patterns here and no single
+   standard approache employed by developers, further exacerbating any analysis
+   attempts as per problem (1).
+3. `Worker` is a global variable, unlike dynamic `import()`, further
+   complicating any type of static preloading systems or tooling-based analysis.
 
-This results in a situation where it is very difficult to statically analyze
-which modules are loaded in workers. This causes two major problems:
-
-1. Runtimes are unable to preload or optimize the worker loading until it is
-dynamically executed, resulting in the waterfall for a module worker happening
-very late.
-2. Bundlers and tools are unable to know statically which modules are being
-imported, so they can bundle them into the output, or emit new entrypoints
-for entrypoint modules (as is the case with workers).
+Usage examples:
 
 ```js
 // Common case, but requires very non-trivial static analysis
@@ -75,6 +49,18 @@ function createWorker(specifier) {
 const url = new URL("./my_worker.js", import.meta.url);
 const processor = createWorker(url);
 ```
+
+The result is a situation in which is is difficult to reliably statically
+analyze which modules are loaded in workers, causing issues for runtimes and
+tools:
+
+* Runtimes are cannot easily speculatively preload or optimize worker loading
+  prior to the immediate execution of `new Worker()`, resulting in the waterfall
+  for a module worker happening very late, with non-ideal performance
+  characteristics.
+* Tools have difficulty both analyzing and bundling applications that use
+  workers, resulting in less usage and limited compatibility for shared
+  libraries to support workers.
 
 A better language primitive for worker loading can resolve all three of these
 static analysis gaps improving the situation for analysis, build and runtime
@@ -94,15 +80,51 @@ const worker = new Worker(myModule);
 ```
 
 This technique would solve analysis problems (1) and (2) for worker imports in
-supporting static worker references, that resolve through the normal module
-resolution rules in being module-relative and supporting all resolution features.
+supporting static worker references, while resolving as module-relative via the
+normal module resolution rules with all resolution features supported.
 
-Runtimes and tooling would be able to statically see what module loading waterfall
-would be happening and provide ahead of time analysis - at runtime to enable
-performance improvements, and for tools to provide stronger static guarantees.
+Because the phase import is static and separate to the worker invocation it also
+does not have analysis problem (3), therefore:
+
+* Runtimes can statically determine that a module graph is being loaded (even
+  if it is not yet known it will be loaded in a worker), and trigger
+  ahead-of-time network preloading for the associated module graph and
+  dependencies.
+* Tools can both statically analyze new entry points for workers as well as
+  bundle for workers using this syntax (eg by replacing the `./my-module.js`
+  static phase import with a fully optimized chunk to load).
 
 In addition this new phase would then also layer with the future proposals for
 inline modules and virtualization.
+
+Since phases also support a dynamic import form, we would also get the dynamic
+variant:
+
+```js
+const workerModule = await import.somephase('./worker.js');
+new Worker(workerModule);
+```
+
+## Background
+
+With the recently introduced [Source Phase Imports][], it is now possible to
+define import phases that exist prior to the full linking and execution of the
+module graph.
+
+These phases form the basis of a number of new proposals for modules including
+module declarations, module expressions, deferred module imports, virtualization
+through loaders and new worker semantics.
+
+In order to develop these new proposals in a way that aligns with phased
+imports,Currently this phase is not yet specified for ECMAScript modules
+themselves, as we do not have a definition of this object yet for JavaScript.
+
+One of the driving specification constraints for these objects is also how they
+behave when transferred between agents and workers, which we would argue forms
+a critical design space for these features, which is why this proposal is seen
+as the most suitable "next step" in the larger layering efforts.
+
+## Design Questions
 
 ### Module Instance v Module Source
 
@@ -112,211 +134,78 @@ instance or source phase for the module.
 The instance phase represents an entire graph of modules, while the source phase
 represents just a specific module source without its linking being defined.
 
+The benefit of the instance phase being that because it represents the graph, it
+might be more amenable to preloading.
+
+Work to determine which phase to specify is ongoing within this proposal's
+current stage. It may yet specify one or the other, or it may even specify
+_both_ a source and an instance to allow handling some of the deeper tradeoffs
+and layering questions.
+
 ### Transferability
 
 The phase defined for ECMAScript modules may or may not be a transferable phase,
-via `postMessage` into the worker. While source phase is currently transferable,
-instance phase may have more difficulties in transferability due to having to
-handle edge cases around dependency transfer.
+via `postMessage` into the worker. The transerability question is also separate
+to the question of supporting `new Worker(phase)` invocation, which can be
+supported for a given phase as separate to the concept of transder.
 
-### Dynamic Phase Imports
-
-Since phases also support a dynamic import form, we also get the dynamic
-variant:
-
-```
-const workerModule = await import.somephase('./worker.js');
-new Worker(workerModule);
-```
-
-with these dynamic forms solving analysis problem (3) as stated in the
-motivation.
+The source phase is currently transferable, while the instance phase may have
+more difficulties in transferability due to having to handle edge cases around
+module identity for dependency transfer.
 
 ## Layering
 
-### Import attributes
+### Source Phase Imports
 
-The import attributes proposal provides a way to pass attributes to the module
-loader. Just like with "source" phase imports, this proposal composes with the
-import attributes proposal, allowing attributes to be passed on module instance
-imports.
-
-The attributes are used during source loading and resolution, like specified for
-"source" phase imports. The module source and module instance has already gone
-through this process, so it is already "attributes-influenced". This means that
-when you pass a module instance or module source to a dynamic `import()` or `new
-Worker`, you can not pass additional `with` attributes, and setting attributes
-in `import()` would throw an error.
-
-### Source phase imports
-
-This proposal is designed to work in conjunction with "source" phase imports,
+This proposal is designed to work in conjunction with [Source Phase Imports][],
 whether or not it directly specifies a source phase for ECMAScript modules.
 
-### Module expressions & declarations
+### Import Attributes
 
-The module object returned from the phased import should be based on the same
-foundations as the module objects of module expressions and module declarations.
+The [Import Attributes Proposal][] provides a way to pass attributes to the
+module loader. These attributes are used during source loading and resolution.
+Because th module source and module instance have already gone through this
+process, they are already _attributes-influenced_ by the time their handle is
+obtained.
 
-### Loaders
-
-The loaders proposal provides a way to dynamically create module instances from
-module source objects, optionally providing a custom loader and `import.meta`.
-The module instances created by loaders are the same `Module` object created by
-module instance imports.
-
-The loaders proposal should be layered to use the new phase defined here in
-virtualization, when enabling the creation of dynamic module instances.
+When passing an module instance or module source object to a dynamic `import()`
+or `new Worker`, any additional `with` attributes would therefore be unsupported
+- and setting attributes would throw an error.
 
 ### Deferred imports
 
-The deferred imports proposal provides a way to defer the synchronous evaluation
-of a module until it is needed, but not to defer the linking of the module. This
-is a phase between the "module context attach" phase and the "evaluation" phase.
+The [Deferred Imports][] proposal provides a way to defer the synchronous
+evaluation of a module until it is needed, but not to defer the linking of the
+module. This is a phase between the "module context attach" phase and the
+"evaluation" phase.
 
-This differs from this proposal, because this proposal does not perform eager
-linkage. This is important to support passing module instances to other contexts
-such as Web Workers without the linkage being performed in the current context.
+As an entirely separate phase, this proposal does not otherwise interact with
+the deferred imports proposal.
 
-This proposal does not interact with the deferred imports proposal, except
-through the addition of support for module instances in the `await
-import.defer()` syntax.
+### Module Expressions & Module Declarations
 
-## Use Cases
+The module objects defined by the [Module Expressions][] and
+[Module Declarations][] proposals, should align with whatever SourceTextModule
+phase object foundations are specified in this proposal.
 
-Supporting new static analysis-friendly primitives for managing more complex
-module loading scenarios extends static analysis tools to new uses, including
-the following "in the wild" examples:
+### Compartment Loaders
 
-### Worker bundling in `esbuild`
+The [Compartments Proposal][] provides a way to dynamically create module
+instances from module source objects, optionally providing custom loaders.
 
-`esbuild` does not have smart enough analysis to pick up on `new Worker(new
-URL("./my_worker.js", import.meta.url), ...)` style worker usage, so it is not
-able to automatically bundle workers. Instead, it requires you to manually
-specify the worker as a separate entrypoint in your project, and then manually
-configure your `new Worker` call to load this entrypoint.
-
-This has various drawbacks:
-
-- Code can not run un-bundled (for example in development), because the code is
-  dependant on the bundler emitting a separate entrypoint for the worker at a
-  specific location. This means that bundling can not just be a transparent
-  performance optimization, but rather requires tool specific codebase changes.
-- Significant manual configuration is required on the users part, making the
-  barrier to entry higher for using workers. Generally, we should encourage use
-  of workers to offload work from the main thread that is used for rendering.
-
-### Dynamic import / worker support in `deno compile`
-
-`deno compile` is a feature of Deno that allows running a JavaScript program as
-a standalone executable binary. This works by performing static analysis on the
-module graph during compilation, serializing all modules _as is_ into a special
-container format [eszip](https://github.com/denoland/eszip), and then embedding
-this in a binary.
-
-Upon execution, this binary is then able to load the modules individually from
-the container format, and execute them. No code transformation is performed on
-the source code - all code is executed as is was found on disk prior to
-compilation.
-
-Because at runtime only code embedded in the binary can be loaded, all imported
-code must be statically analyzable. If you want to use dynamic imports to defer
-a slow executing module until it is needed, or want to use web workers to
-offload work from the main thread, you can not do so, because the module was
-never loaded into the binary because it was not found during static analysis.
-
-`deno compile` provides a `--include` flag to enable manually specifying
-additional modules to be treated as entrypoints, but this is a manual process
-that requires you to specify workers and dynamic imports both in code, and in a
-build script. Errors from mis-configuration can not be caught at compile time
-(because lack of static analysis, duh!), so necessarily result in runtime
-exceptions, which is subpar.
-
-### Dependency graph visualization in Deno
-
-Deno provides a `deno info` command that allows you to visualize the dependency
-graph of a module, starting at it's entrypoint. This is useful for understanding
-the structure of a codebase, and for debugging dependency cycles.
-
-However, because `deno info` only performs static analysis, it can not visualize
-the dependency graph of modules that are referenced in ways that are not
-trivially statically analyzable. This includes dynamic imports, and workers.
-
-### Dynamic I/O permissions required to start workers in Deno
-
-Deno provides a relatively sophisticated permissions system, that allows you to
-lock down which I/O operations can be performed at runtime. It can be configured
-through flags passed to the `deno` executable, or dynamically using user
-prompts.
-
-When a user performs an import of a local file on disk, this is considered I/O
-and requires the relevant file system permission to be set. There is however a
-special bypass to this permission check for the entrypoint module, all modules
-that are statically reachable from that entrypoint. This means that if you have
-a file `./main.ts` that imports a file `./b.ts`, you do not need to have read
-permissions for either `./main.ts` or `./b.ts` to execute this entrypoint. This
-is safe, because a user can visualize all files that are statically reachable
-from the entrypoint before execution (using `deno info`).
-
-There is no static analysis for modules used to start workers, and as such there
-is no way to know up front that that given module is part of the module graph,
-which means it can not be exempted from the permissions check like static
-imports can. This means that starting a worker always requires a permission
-check for that file, and all files it imports.
-
-This makes building granular allow-lists of files that are allowed to be read
-very difficult.
-
-This also significantly increases the barrier of entry for using workers,
-because they don't just work "as is", like regular static imports. This is bad,
-because we want to encourage users to run heavy compute tasks off-main-thread.
-
-### Third-party modules using workers
-
-All of the problems described above get exponentially worse when thinking about
-workers inside of third party libraries. When a worker is used inside of a third
-party library, and a bundler or other static analysis tool can not pick it up
-automatically, this requires the user to manually tweak their build tooling to
-explicitly specify workers internal to third party dependencies.
-
-This is so cumbersome for end users that library authors often avoid using
-workers entirely, even when it would be beneficial to do so, because of the
-significant added complexity to end-users. This is bad, because we want to
-encourage library authors to use workers to offload heavy compute tasks from the
-main thread.
-
-The Wasm build of `esbuild` itself is a good example of a workaround that is
-very frustrating for users. It embeds worker source code in a JS file as a
-string literal, and then passes this string to a Worker constructor using a blob
-URL (see line 1813 of
-https://unpkg.com/browse/esbuild-wasm@0.19.2/lib/browser.js). This results in
-all stack traces from within this worker to be completely useless, because it
-points to the blob URL, and not a readable source file.
-
-### Capability based imports
-
-Capability based imports is a new security primitive that arises from this
-proposal. Let's imagine a scenario with two separate JavaScript realms, one on
-the main thread, and one on a worker thread. The main thread worker has broad
-permissions, and is a trusted hypervisor. The worker thread is untrusted, and
-has limited permissions. It does not allow `eval` or other dynamic code
-execution, and does not allow access to the file system or network. The question
-that arises now is: "How can the worker thread execute any code, if it can't
-evaluate strings, and can't load any modules from disk or network?"
-
-This is where module phases can be useful. The main thread (trusted) can load
-a module from disk or network, from audited/trusted sources, and then pass the
-static module phase to the worker thread to be executed. The worker thread can
-then evaluate the module, without having to recheck permissions or evaluate any
-arbitrary strings. In essence, the worker thread can only execute code that was
-already audited by the main thread. It gets access to this evaluation capability
-by being passed a module phase, so the module phase is a capability object.
-
-Together with the [loaders proposal](https://github.com/tc39/proposal-compartments)
-this proposal can provide novel sandboxing techniques using workers.
+The module source and module instance definitions are being aligned with the
+definitions in use within this proposal and others. Where they are specified
+in this proposal or others, the compartment loaders proposal may extend their
+functionality further in future by adding new methods to these existing objects
+for example.
 
 ## Q&A
 
-_Post an [issue](https://github.com/lucacasonato/proposal-module-instance-imports/issues)_
+_Post an [issue](https://github.com/lucacasonato/proposal-module-instance-imports/issues)._
 
+[Deferred Imports]: https://github.com/tc39/proposal-defer-import-eval
+[Loaders Proposal]: [https://github.com/tc39/proposal-compartments/blob/master/0-module-and-module-source.md]
+[Import Attributes Proposal]: https://github.com/tc39/proposal-import-attributes
+[Module Expressions]: https://github.com/tc39/proposal-module-expressions
+[Module Declarations]: https://github.com/tc39/proposal-module-declarations
 [Source Phase Imports]: https://github.com/tc39/proposal-source-phase-imports

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Phase Imports for SourceTextModule
+# Source Text Phase Imports
 
 ## Status
 
@@ -9,7 +9,7 @@ Stage: 0
 ## Problem Statement
 
 This proposal seeks to solve the _static worker_ module analysis problem for
-JavaScript, through defining a suitable phase import for SourceTextModule.
+JavaScript, through defining suitable phase imports for Source Text Module.
 
 ## Motivation
 

--- a/spec.emu
+++ b/spec.emu
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="./spec.js"></script>
 <pre class="metadata">
-title: Module Instance Imports
+title: Static Module Instance & Module Source
 stage: 0
 contributors: Luca Casonato
 </pre>

--- a/spec.emu
+++ b/spec.emu
@@ -4,9 +4,9 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="./spec.js"></script>
 <pre class="metadata">
-title: Phase Imports for SourceTextModule
+title: Source Text Phase Imports
 stage: 0
-contributors: Luca Casonato
+contributors: Luca Casonato, Guy Bedford
 </pre>
 
 <emu-clause id="sec-demo-clause">

--- a/spec.emu
+++ b/spec.emu
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="./spec.js"></script>
 <pre class="metadata">
-title: Static Module Instance & Module Source
+title: Phase Imports for SourceTextModule
 stage: 0
 contributors: Luca Casonato
 </pre>

--- a/spec.emu
+++ b/spec.emu
@@ -4,7 +4,7 @@
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/styles/github.min.css">
 <script src="./spec.js"></script>
 <pre class="metadata">
-title: Source Text Phase Imports
+title: ECMAScript Module Phase Imports
 stage: 0
 contributors: Luca Casonato, Guy Bedford
 </pre>


### PR DESCRIPTION
As discussed in the previous meeting, this restructures the proposal to focus first and foremost on the worker problem statement exactly as it has been doing, but with a bunch of simplifications around presenting that and putting the statement first.

The background mentions how in our overall layering work this is seen as a good next step due to the importance of the worker design constraints.

I've kept the proposal layering section, with rewriting for applying to both source and instance.

All of the use cases touched on in the use cases section should be covered by the motivation now, but please let me know if there is anything else there we should keep - I entirely removed the capability section as I wasn't sure how to frame this into the worker problem statement, but I'm open to bringing it back in some form if necessary.

The renaming to 'Source Text Phase Imports' is to indicate that the exact phase definition is not yet fully clear for the Stage 1 proposal phase, to give us some design flexibility here.